### PR TITLE
Fix typo For IWorkBuilder.WithVersion

### DIFF
--- a/src/core/Elsa.Core/Builders/WorkflowBuilder.cs
+++ b/src/core/Elsa.Core/Builders/WorkflowBuilder.cs
@@ -83,7 +83,7 @@ namespace Elsa.Builders
         {
             Version = value;
             IsLatest = isLatest;
-            isPublished = isPublished;
+            IsPublished = isPublished;
             return this;
         }
         


### PR DESCRIPTION
Assignment made to the parameter `isPublished` is not necessary. Changes should be made to the `IsPublished` Property